### PR TITLE
Fix storage of account value

### DIFF
--- a/packages/web/workspace/src/providers/auth.tsx
+++ b/packages/web/workspace/src/providers/auth.tsx
@@ -61,7 +61,7 @@ export function AuthProvider(props: ParentProps) {
       token: access_token,
       ...payload.properties,
     };
-    account.set(payload.properties.accountID);
+    account.set('account', payload.properties.accountID);
     set(tokens);
   }
 


### PR DESCRIPTION
The missing key for the call to set results in each character of the accountID being stored against numerical keys in the localstorage.

This hasn't yet manifested as a problem because the `*` route also calls to set this value before redirecting. If you remove that logic in the route definitions this provider would not work.

<img width="904" alt="Screenshot 2023-08-12 at 22 22 51" src="https://github.com/sst/console/assets/62936/9f4597e5-5507-4b32-b40c-f76ceb70efb2">
