### PR TITLE
fix: hint to show numeric keyboard for verification

### DIFF
--- a/packages/web/workspace/src/pages/auth/index.tsx
+++ b/packages/web/workspace/src/pages/auth/index.tsx
@@ -253,6 +253,7 @@ export function Code() {
                 }}
                 data-element="code"
                 maxLength={1}
+                inputmode="numeric"
                 autofocus
                 disabled={disabled()}
                 type="text"


### PR DESCRIPTION
I haven't verified this but this should enable iOS to show numeric keyboard rather than text.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inputMode

---

<details>
<summary>current appearance</summary>

![IMG_3278](https://github.com/sst/console/assets/28706372/b7f5ff81-6dc7-4d62-9a1e-41d66d9bc9c2)

</details>