### PR TITLE
fix: auth clientId typo

### DIFF
--- a/packages/web/workspace/src/providers/auth.tsx
+++ b/packages/web/workspace/src/providers/auth.tsx
@@ -33,7 +33,7 @@ export const { use: useAuth, provider: AuthProvider } =
         accounts: {},
       }),
       {
-        name: "radiant.auth",
+        name: "sst.auth",
       },
     );
     const location = useLocation();


### PR DESCRIPTION
Just noticed this when reading over the openauth spa implementation and noticed the name was radiant not sst. 

disclaimer, I didn't really double-check to see if this was/wasn't intended, but guessing a copy/paste?